### PR TITLE
Config obj memory footprint issue

### DIFF
--- a/src/main/java/org/apache/ibatis/parsing/XNode.java
+++ b/src/main/java/org/apache/ibatis/parsing/XNode.java
@@ -360,5 +360,22 @@ public class XNode {
     }
     return null;
   }
+  
+  public String toStringWithContent() {
+    StringBuilder builder = new StringBuilder();
+    toStringWithContent(builder);
+    return builder.toString();
+  }
+  
+  private void toStringWithContent(StringBuilder builder) {
+    builder.append(toString());
+    Node clonedNode = getNode().cloneNode(true);
+    builder.append("<textContent>");
+    builder.append(clonedNode.getTextContent());
+    builder.append("<textContent>");
+    builder.append("<body>");
+    builder.append(body);
+    builder.append("<body>");
+  }
 
 }

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -15,7 +15,11 @@
  */
 package org.apache.ibatis.scripting.xmltags;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,15 +82,30 @@ public class XMLScriptBuilder extends BaseBuilder {
     NodeList children = node.getNode().getChildNodes();
     for (int i = 0; i < children.getLength(); i++) {
       XNode child = node.newXNode(children.item(i));
-      if (child.getNode().getNodeType() == Node.CDATA_SECTION_NODE || child.getNode().getNodeType() == Node.TEXT_NODE) {
-        String data = child.getStringBody("");
-        TextSqlNode textSqlNode = new TextSqlNode(data);
-        if (textSqlNode.isDynamic()) {
-          contents.add(textSqlNode);
-          isDynamic = true;
-        } else {
-          contents.add(new StaticTextSqlNode(data));
-        }
+	if (child.getNode().getNodeType() == Node.CDATA_SECTION_NODE
+			|| child.getNode().getNodeType() == Node.TEXT_NODE) {
+		String key = getHash(child.getStringBody(""));
+		if (configuration.containsSqlNode(key)) {
+			SqlNode sqlNode = configuration.getSqlNode(key);
+			if (sqlNode instanceof TextSqlNode) {
+				isDynamic = true;
+			}
+			contents.add(sqlNode);
+		} else {
+			String data = child.getStringBody("").replaceAll("\t", " ").replaceAll("\n", " ");
+			if(data.trim().length()>0) {
+				TextSqlNode textSqlNode = new TextSqlNode(data);
+				if (textSqlNode.isDynamic()) {
+					contents.add(textSqlNode);
+					isDynamic = true;
+					configuration.addSqlNode(key, textSqlNode);
+				} else {
+					StaticTextSqlNode staticTextSqlNode = new StaticTextSqlNode(data);
+					contents.add(staticTextSqlNode);
+					configuration.addSqlNode(key, staticTextSqlNode);
+				}
+			}
+		}
       } else if (child.getNode().getNodeType() == Node.ELEMENT_NODE) { // issue #628
         String nodeName = child.getNode().getNodeName();
         NodeHandler handler = nodeHandlerMap.get(nodeName);
@@ -100,9 +119,30 @@ public class XMLScriptBuilder extends BaseBuilder {
     return new MixedSqlNode(contents);
   }
 
-  private interface NodeHandler {
-    void handleNode(XNode nodeToHandle, List<SqlNode> targetContents);
-  }
+	private MixedSqlNode getMixedNode(XNode nodeToHandle) {
+		String key = getHash(nodeToHandle.toStringWithContent());
+		if (configuration.containsSqlNode(key)) {
+			return (MixedSqlNode)configuration.getSqlNode(key);
+		} else {
+			MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
+			configuration.addSqlNode(key, mixedSqlNode);
+			return mixedSqlNode;
+		}
+	}
+
+	private String getHash(String key) {
+		try {
+			MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+			byte hashBytes[] = messageDigest.digest(key.getBytes(StandardCharsets.UTF_8));
+			return Base64.getEncoder().encodeToString(hashBytes);
+		} catch (NoSuchAlgorithmException e) {
+			return key;
+		}
+	}
+
+	private interface NodeHandler {
+	    void handleNode(XNode nodeToHandle, List<SqlNode> targetContents);
+	}
 
   private static class BindHandler implements NodeHandler {
     public BindHandler() {
@@ -110,12 +150,18 @@ public class XMLScriptBuilder extends BaseBuilder {
     }
 
     @Override
-    public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
-      final String name = nodeToHandle.getStringAttribute("name");
-      final String expression = nodeToHandle.getStringAttribute("value");
-      final VarDeclSqlNode node = new VarDeclSqlNode(name, expression);
-      targetContents.add(node);
-    }
+	public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
+		final String name = nodeToHandle.getStringAttribute("name");
+		final String expression = nodeToHandle.getStringAttribute("value");
+		String key = getHash(nodeToHandle.toStringWithContent());
+		if (configuration.containsSqlNode(key)) {
+			targetContents.add(configuration.getSqlNode(key));
+		} else {
+			SqlNode sqlNode = new VarDeclSqlNode(name, expression);
+			configuration.addSqlNode(key, sqlNode);
+			targetContents.add(sqlNode);
+		}
+	}
   }
 
   private class TrimHandler implements NodeHandler {
@@ -125,27 +171,25 @@ public class XMLScriptBuilder extends BaseBuilder {
 
     @Override
     public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
-      MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
+      MixedSqlNode mixedSqlNode = getMixedNode(nodeToHandle);
       String prefix = nodeToHandle.getStringAttribute("prefix");
       String prefixOverrides = nodeToHandle.getStringAttribute("prefixOverrides");
       String suffix = nodeToHandle.getStringAttribute("suffix");
       String suffixOverrides = nodeToHandle.getStringAttribute("suffixOverrides");
-      TrimSqlNode trim = new TrimSqlNode(configuration, mixedSqlNode, prefix, prefixOverrides, suffix, suffixOverrides);
-      targetContents.add(trim);
-    }
-  }
+			targetContents.add(new TrimSqlNode(configuration, mixedSqlNode, prefix, prefixOverrides, suffix, suffixOverrides));
+		}
+	}
 
   private class WhereHandler implements NodeHandler {
     public WhereHandler() {
       // Prevent Synthetic Access
     }
 
-    @Override
-    public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
-      MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
-      WhereSqlNode where = new WhereSqlNode(configuration, mixedSqlNode);
-      targetContents.add(where);
-    }
+		@Override
+		public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
+			MixedSqlNode mixedSqlNode = getMixedNode(nodeToHandle);
+			targetContents.add( new WhereSqlNode(configuration, mixedSqlNode));
+		}
   }
 
   private class SetHandler implements NodeHandler {
@@ -153,12 +197,11 @@ public class XMLScriptBuilder extends BaseBuilder {
       // Prevent Synthetic Access
     }
 
-    @Override
-    public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
-      MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
-      SetSqlNode set = new SetSqlNode(configuration, mixedSqlNode);
-      targetContents.add(set);
-    }
+		@Override
+		public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
+			MixedSqlNode mixedSqlNode = getMixedNode(nodeToHandle);
+			targetContents.add(new SetSqlNode(configuration, mixedSqlNode));
+		}
   }
 
   private class ForEachHandler implements NodeHandler {
@@ -166,20 +209,18 @@ public class XMLScriptBuilder extends BaseBuilder {
       // Prevent Synthetic Access
     }
 
-    @Override
-    public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
-      MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
-      String collection = nodeToHandle.getStringAttribute("collection");
-      Boolean nullable = nodeToHandle.getBooleanAttribute("nullable");
-      String item = nodeToHandle.getStringAttribute("item");
-      String index = nodeToHandle.getStringAttribute("index");
-      String open = nodeToHandle.getStringAttribute("open");
-      String close = nodeToHandle.getStringAttribute("close");
-      String separator = nodeToHandle.getStringAttribute("separator");
-      ForEachSqlNode forEachSqlNode = new ForEachSqlNode(configuration, mixedSqlNode, collection, nullable, index, item,
-          open, close, separator);
-      targetContents.add(forEachSqlNode);
-    }
+		@Override
+		public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
+			MixedSqlNode mixedSqlNode = getMixedNode(nodeToHandle);
+			String collection = nodeToHandle.getStringAttribute("collection");
+			Boolean nullable = nodeToHandle.getBooleanAttribute("nullable");
+			String item = nodeToHandle.getStringAttribute("item");
+			String index = nodeToHandle.getStringAttribute("index");
+			String open = nodeToHandle.getStringAttribute("open");
+			String close = nodeToHandle.getStringAttribute("close");
+			String separator = nodeToHandle.getStringAttribute("separator");
+			targetContents.add( new ForEachSqlNode(configuration, mixedSqlNode, collection, nullable, index, item, open, close, separator));
+		}
   }
 
   private class IfHandler implements NodeHandler {
@@ -187,13 +228,12 @@ public class XMLScriptBuilder extends BaseBuilder {
       // Prevent Synthetic Access
     }
 
-    @Override
-    public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
-      MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
-      String test = nodeToHandle.getStringAttribute("test");
-      IfSqlNode ifSqlNode = new IfSqlNode(mixedSqlNode, test);
-      targetContents.add(ifSqlNode);
-    }
+		@Override
+		public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
+			MixedSqlNode mixedSqlNode = getMixedNode(nodeToHandle);
+			String test = nodeToHandle.getStringAttribute("test");
+			targetContents.add(new IfSqlNode(mixedSqlNode, test));
+		}
   }
 
   private class OtherwiseHandler implements NodeHandler {
@@ -201,11 +241,17 @@ public class XMLScriptBuilder extends BaseBuilder {
       // Prevent Synthetic Access
     }
 
-    @Override
-    public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
-      MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
-      targetContents.add(mixedSqlNode);
-    }
+		@Override
+		public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
+			String key = getHash(nodeToHandle.toStringWithContent());
+			if (configuration.containsSqlNode(key)) {
+				targetContents.add(configuration.getSqlNode(key));
+			} else {
+				SqlNode sqlNode = parseDynamicTags(nodeToHandle);
+				configuration.addSqlNode(key, sqlNode);
+				targetContents.add(sqlNode);
+			}
+		}
   }
 
   private class ChooseHandler implements NodeHandler {
@@ -218,10 +264,9 @@ public class XMLScriptBuilder extends BaseBuilder {
       List<SqlNode> whenSqlNodes = new ArrayList<>();
       List<SqlNode> otherwiseSqlNodes = new ArrayList<>();
       handleWhenOtherwiseNodes(nodeToHandle, whenSqlNodes, otherwiseSqlNodes);
-      SqlNode defaultSqlNode = getDefaultSqlNode(otherwiseSqlNodes);
-      ChooseSqlNode chooseSqlNode = new ChooseSqlNode(whenSqlNodes, defaultSqlNode);
-      targetContents.add(chooseSqlNode);
-    }
+			SqlNode defaultSqlNode = getDefaultSqlNode(otherwiseSqlNodes);
+			targetContents.add(new ChooseSqlNode(whenSqlNodes, defaultSqlNode));
+		}
 
     private void handleWhenOtherwiseNodes(XNode chooseSqlNode, List<SqlNode> ifSqlNodes,
         List<SqlNode> defaultSqlNodes) {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
 import org.apache.ibatis.binding.MapperRegistry;
@@ -87,6 +88,7 @@ import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.scripting.LanguageDriverRegistry;
 import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
+import org.apache.ibatis.scripting.xmltags.SqlNode;
 import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 import org.apache.ibatis.transaction.Transaction;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
@@ -160,6 +162,7 @@ public class Configuration {
           .conflictMessageProducer((savedValue, targetValue) -> ". please check " + savedValue.getResource() + " and "
               + targetValue.getResource());
   protected final Map<String, Cache> caches = new StrictMap<>("Caches collection");
+  protected final Map<String, SqlNode> sqlNodes = new HashMap<>();
   protected final Map<String, ResultMap> resultMaps = new StrictMap<>("Result Maps collection");
   protected final Map<String, ParameterMap> parameterMaps = new StrictMap<>("Parameter Maps collection");
   protected final Map<String, KeyGenerator> keyGenerators = new StrictMap<>("Key Generators collection");
@@ -804,6 +807,18 @@ public class Configuration {
 
   public Collection<String> getParameterMapNames() {
     return parameterMaps.keySet();
+  }
+
+  public void addSqlNode(String key, SqlNode sqlNode) {
+    sqlNodes.put(key, sqlNode);
+  }
+  
+  public boolean containsSqlNode(String key) {
+    return sqlNodes.containsKey(key);
+  }
+  
+  public SqlNode getSqlNode(String key) {
+    return sqlNodes.get(key);
   }
 
   public Collection<ParameterMap> getParameterMaps() {


### PR DESCRIPTION
Team, 

We found some fundamental memory issue with configuration object. We observed that, we are repeatedly parsing the same XNodes and creating SQL nodes, instead of reusing the previously created SQLNode for the Xnode. 
These changes holds the sqlNodeMap which consists of Xnode String(query String) as key, and respective SQLNode as value. So that, whenver we came across the same Xnode reference, we will use the previously created object from Map. This reduces the overall SQLNode Objects, and memory foot print of Configuration object. 

These changes are already tested and validated in our project for more 10months. 